### PR TITLE
Use PropTypes Packacge

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsdom": "^9.0.0",
     "mocha": "^2.3.3",
     "proxyquire": "^1.7.3",
-    "prop-types": '15.5.8',
+    "prop-types": "15.5.8",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jsdom": "^9.0.0",
     "mocha": "^2.3.3",
     "proxyquire": "^1.7.3",
+    "prop-types": '15.5.8',
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",

--- a/src/FacebookPlayer.js
+++ b/src/FacebookPlayer.js
@@ -1,23 +1,24 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import { string, number, func } from 'prop-types';
 
-class FacebookPlayer extends Component {
+class FacebookPlayer extends React.Component {
   static propTypes = {
-    id: PropTypes.string,
-    className: PropTypes.string,
-    appId: PropTypes.string.isRequired,
-    videoId: PropTypes.string.isRequired,
-    width: PropTypes.number,
-    allowfullscreen: PropTypes.string,
-    autoplay: PropTypes.string,
-    showText: PropTypes.string,
-    showCaptions: PropTypes.string,
-    onReady: PropTypes.func,
-    onStartedPlaying: PropTypes.func,
-    onPaused: PropTypes.func,
-    onFinishedPlaying: PropTypes.func,
-    onStartedBuffering: PropTypes.func,
-    onFinishedBuffering: PropTypes.func,
-    onError: PropTypes.func,
+    id: string,
+    className: string,
+    appId: string.isRequired,
+    videoId: string.isRequired,
+    width: number,
+    allowfullscreen: string,
+    autoplay: string,
+    showText: string,
+    showCaptions: string,
+    onReady: func,
+    onStartedPlaying: func,
+    onPaused: func,
+    onFinishedPlaying: func,
+    onStartedBuffering: func,
+    onFinishedBuffering: func,
+    onError: func
   };
 
   constructor(props) {


### PR DESCRIPTION
As per React 15.5: 

"Note: React.PropTypes is deprecated as of React v15.5. Please use the prop-types library instead."

This PR updates the code for using prop-types to the new external library. 