### PR TITLE
Boolean type options should be booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ const FacebookPlayer = require('react-facebook-player');
   id={ string }                                       # Element ID. Required if you wanna use more than one video in the same page.
   className={ string }                                # Element class.
   /* ATTRIBUTES. Ref: http://bit.ly/29OOzWZ */
-  allowfullscreen={ string }
-  autoplay={ string }
+  allowfullscreen={ boolean }
+  autoplay={ boolean }
   width={ number }
-  showText={ string }
-  showCaptions={ string }
+  showText={ boolean }
+  showCaptions={ boolean }
   /* EVENTS. Ref: http://bit.ly/29JaA7J */
   onReady={ function }                                # Returns a player object to be used for controlling
   onStartedPlaying={ function }

--- a/dist/FacebookPlayer.js
+++ b/dist/FacebookPlayer.js
@@ -82,11 +82,11 @@ var FacebookPlayer = function (_React$Component) {
       playerDiv.classList.add('fb-video');
       playerDiv.id = playerId;
       playerDiv.setAttribute('data-href', 'https://www.facebook.com/facebook/videos/' + videoId);
-      playerDiv.setAttribute('data-allowfullscreen', allowfullscreen || 'false');
-      playerDiv.setAttribute('data-autoplay', autoplay || 'false');
-      playerDiv.setAttribute('data-width', width || 'auto');
-      playerDiv.setAttribute('data-show-text', showText || 'false');
-      playerDiv.setAttribute('data-show-captions', showCaptions || 'false');
+      playerDiv.setAttribute('data-allowfullscreen', allowfullscreen);
+      playerDiv.setAttribute('data-autoplay', autoplay);
+      playerDiv.setAttribute('data-width', width);
+      playerDiv.setAttribute('data-show-text', showText);
+      playerDiv.setAttribute('data-show-captions', showCaptions);
 
       _this.container.appendChild(playerDiv);
 
@@ -273,10 +273,10 @@ FacebookPlayer.propTypes = {
   appId: _propTypes.string.isRequired,
   videoId: _propTypes.string.isRequired,
   width: _propTypes.number,
-  allowfullscreen: _propTypes.string,
-  autoplay: _propTypes.string,
-  showText: _propTypes.string,
-  showCaptions: _propTypes.string,
+  allowfullscreen: _propTypes.bool,
+  autoplay: _propTypes.bool,
+  showText: _propTypes.bool,
+  showCaptions: _propTypes.bool,
   onReady: _propTypes.func,
   onStartedPlaying: _propTypes.func,
   onPaused: _propTypes.func,
@@ -284,5 +284,12 @@ FacebookPlayer.propTypes = {
   onStartedBuffering: _propTypes.func,
   onFinishedBuffering: _propTypes.func,
   onError: _propTypes.func
+};
+FacebookPlayer.defaultProps = {
+  allowfullscreen: false,
+  autoplay: false,
+  showText: false,
+  showCaptions: false,
+  width: 'auto'
 };
 exports.default = FacebookPlayer;

--- a/src/FacebookPlayer.js
+++ b/src/FacebookPlayer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, number, func } from 'prop-types';
+import { string, number, func, bool } from 'prop-types';
 
 class FacebookPlayer extends React.Component {
   static propTypes = {
@@ -8,10 +8,10 @@ class FacebookPlayer extends React.Component {
     appId: string.isRequired,
     videoId: string.isRequired,
     width: number,
-    allowfullscreen: string,
-    autoplay: string,
-    showText: string,
-    showCaptions: string,
+    allowfullscreen: bool,
+    autoplay: bool,
+    showText: bool,
+    showCaptions: bool,
     onReady: func,
     onStartedPlaying: func,
     onPaused: func,
@@ -20,6 +20,14 @@ class FacebookPlayer extends React.Component {
     onFinishedBuffering: func,
     onError: func,
   };
+
+  static defaultProps = {
+    allowfullscreen: false,
+    autoplay: false,
+    showText: false,
+    showCaptions: false,
+    width: 'auto',
+  }
 
   constructor(props) {
     super(props);
@@ -160,11 +168,11 @@ class FacebookPlayer extends React.Component {
     playerDiv.classList.add('fb-video');
     playerDiv.id = playerId;
     playerDiv.setAttribute('data-href', 'https://www.facebook.com/facebook/videos/' + videoId);
-    playerDiv.setAttribute('data-allowfullscreen', allowfullscreen || 'false');
-    playerDiv.setAttribute('data-autoplay', autoplay || 'false');
-    playerDiv.setAttribute('data-width', width || 'auto');
-    playerDiv.setAttribute('data-show-text', showText || 'false');
-    playerDiv.setAttribute('data-show-captions', showCaptions || 'false');
+    playerDiv.setAttribute('data-allowfullscreen', allowfullscreen);
+    playerDiv.setAttribute('data-autoplay', autoplay);
+    playerDiv.setAttribute('data-width', width);
+    playerDiv.setAttribute('data-show-text', showText);
+    playerDiv.setAttribute('data-show-captions', showCaptions);
 
     this.container.appendChild(playerDiv);
 


### PR DESCRIPTION
Hey, thanks for the library!

This PR changes boolean type options to be validated as booleans by `prop-types`.