### PR TITLE
Pass only player instance to onReady

### DIFF
--- a/src/FacebookPlayer.js
+++ b/src/FacebookPlayer.js
@@ -194,7 +194,7 @@ class FacebookPlayer extends React.Component {
         this.videoPlayer = msg.instance;
 
         // Dispatch ready event
-        if (onReady) onReady(id, this.videoPlayer);
+        if (onReady) onReady(this.videoPlayer);
 
         // Subscribe to events
         this.subscribe();


### PR DESCRIPTION
Hey!

First off, thanks for sharing this component! I am not well-versed in Facebook's social plugins and your code helped me display Facebook's video player in no time.

I noticed that in the code you are passing `id` as a first parameter to `onReady` even though you mention in Usage part of README as well as in example that `onReady` gets only the player instance as a param. So this pull request is making sure the `onReady` is called with player instance as a first parameter.